### PR TITLE
fix: fit dashboard to the fullscreen

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -28,7 +28,13 @@ html {
     height: 100vh;
 }
 
-.carousel-item-analytics img {
+.carousel-item iframe {
+    object-fit: cover;
+    width: 100vw;
+    height: 100vh;
+}
+
+.carousel-item-analytics iframe {
     object-fit: contain;
 }
 

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -28,6 +28,10 @@ html {
     height: 100vh;
 }
 
+.carousel-item-analytics img {
+    object-fit: contain;
+}
+
 .carousel-item iframe {
     object-fit: cover;
     width: 100vw;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://genai-analytics--dx-recognitions--hlxscreens.hlx.page/content/screens/org-amitabh/dashboards/analytics-genai-dashboard/dashboard-images
- After: https://dx-grafana--dx-recognitions--hlxscreens.hlx.page/content/screens/org-amitabh/dashboards/analytics-genai-dashboard/dashboard-images
Channel plays dashboard url or a fallback image is a url is not found
https://github.com/user-attachments/assets/b26b56dd-307c-4afb-9f36-d28d48bd08ae

Channel: https://adobe.sharepoint.com/:w:/r/sites/HelixScreensProjects/_layouts/15/Doc.aspx?sourcedoc=%7BADBBED9E-6552-429D-8171-985AEDBBDD63%7D&file=dashboard-images.docx&action=default&mobileredirect=true
