### PR TITLE
Upgrade offline-resource-generator to version 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node-fetch": "^3.3.0",
     "cheerio": "^1.0.0-rc.12",
     "fs-extra": "^11.1.1",
-    "@aem-screens/screens-offlineresources-generator": "1.0.4"
+    "@aem-screens/screens-offlineresources-generator": "1.0.5"
   },
   "devDependencies": {
     "@babel/core": "7.21.0",


### PR DESCRIPTION
This version upgrade includes a fix for incorrect `lastModified` along with code refactoring and readability improvements, sorting of the `channels.json`. 
Changes: https://github.com/adobe/aemscreens-offlineresources-generator/pull/17 

Tested the changes by running the offline-resource-generator locally.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--<repo>--<owner>.hlx.page/
- After: https://<branch>--<repo>--<owner>.hlx.page/
